### PR TITLE
chore: make dumi types can be resolved

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,11 +12,12 @@
         "src/*"
       ],
       "@@/*": [
-        "src/.umi/*"
+        ".dumi/tmp/*"
       ],
       "@rc-component/context": [
         "src/index.ts"
       ]
     }
-  }
+  },
+  "include": [".dumi/**/*", ".dumirc.ts", "src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
       ]
     }
   },
-  "include": [".dumi/**/*", ".dumirc.ts", "src/**/*"]
+  "include": [".dumi/**/*", ".dumirc.ts", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
修复 `.dumirc.ts` 里 `defineConfig` 类型缺失的问题