### PR TITLE
feat: support createImmutable

### DIFF
--- a/src/Immutable.tsx
+++ b/src/Immutable.tsx
@@ -1,23 +1,27 @@
 import { supportRef } from 'rc-util/lib/ref';
 import * as React from 'react';
 
-const ImmutableContext = React.createContext<number>(0);
-
 export type CompareProps<T extends React.ComponentType<any>> = (
   prevProps: Readonly<React.ComponentProps<T>>,
   nextProps: Readonly<React.ComponentProps<T>>,
 ) => boolean;
 
 /**
- * Get render update mark by `makeImmutable` root.
- * Do not deps on the return value as render times
- * but only use for `useMemo` or `useCallback` deps.
+ * Create Immutable pair for `makeImmutable` and `responseImmutable`.
  */
-export function useImmutableMark() {
-  return React.useContext(ImmutableContext);
-}
+export default function createImmutable() {
+  const ImmutableContext = React.createContext<number>(null);
 
-/**
+  /**
+   * Get render update mark by `makeImmutable` root.
+   * Do not deps on the return value as render times
+   * but only use for `useMemo` or `useCallback` deps.
+   */
+  function useImmutableMark() {
+    return React.useContext(ImmutableContext);
+  }
+
+  /**
  * Wrapped Component will be marked as Immutable.
  * When Component parent trigger render,
  * it will notice children component (use with `responseImmutable`) node that parent has updated.
@@ -25,65 +29,78 @@ export function useImmutableMark() {
  * @param Component Passed Component
  * @param triggerRender Customize trigger `responseImmutable` children re-render logic. Default will always trigger re-render when this component re-render.
  */
-export function makeImmutable<T extends React.ComponentType<any>>(
-  Component: T,
-  shouldTriggerRender?: CompareProps<T>,
-): T {
-  const refAble = supportRef(Component);
+  function makeImmutable<T extends React.ComponentType<any>>(
+    Component: T,
+    shouldTriggerRender?: CompareProps<T>,
+  ): T {
+    const refAble = supportRef(Component);
 
-  const ImmutableComponent = function (props: any, ref: any) {
-    const refProps = refAble ? { ref } : {};
-    const renderTimesRef = React.useRef(0);
-    const prevProps = React.useRef(props);
+    const ImmutableComponent = function (props: any, ref: any) {
+      const refProps = refAble ? { ref } : {};
+      const renderTimesRef = React.useRef(0);
+      const prevProps = React.useRef(props);
 
-    if (
-      // Always trigger re-render if not provide `notTriggerRender`
-      !shouldTriggerRender ||
-      shouldTriggerRender(prevProps.current, props)
-    ) {
-      renderTimesRef.current += 1;
+      // If parent has the context, we do not wrap it
+      const mark = useImmutableMark();
+      if (mark !== null) {
+        return <Component {...props} {...refProps} />;
+      }
+
+      if (
+        // Always trigger re-render if not provide `notTriggerRender`
+        !shouldTriggerRender ||
+        shouldTriggerRender(prevProps.current, props)
+      ) {
+        renderTimesRef.current += 1;
+      }
+
+      prevProps.current = props;
+
+      return (
+        <ImmutableContext.Provider value={renderTimesRef.current}>
+          <Component {...props} {...refProps} />
+        </ImmutableContext.Provider>
+      );
+    };
+
+    if (process.env.NODE_ENV !== 'production') {
+      ImmutableComponent.displayName = `ImmutableRoot(${Component.displayName || Component.name})`;
     }
 
-    prevProps.current = props;
-
-    return (
-      <ImmutableContext.Provider value={renderTimesRef.current}>
-        <Component {...props} {...refProps} />
-      </ImmutableContext.Provider>
-    );
-  };
-
-  if (process.env.NODE_ENV !== 'production') {
-    ImmutableComponent.displayName = `ImmutableRoot(${Component.displayName || Component.name})`;
+    return refAble ? React.forwardRef(ImmutableComponent) : (ImmutableComponent as any);
   }
 
-  return refAble ? React.forwardRef(ImmutableComponent) : (ImmutableComponent as any);
-}
+  /**
+   * Wrapped Component with `React.memo`.
+   * But will rerender when parent with `makeImmutable` rerender.
+   */
+  function responseImmutable<T extends React.ComponentType<any>>(
+    Component: T,
+    propsAreEqual?: CompareProps<T>,
+  ): T {
+    const refAble = supportRef(Component);
 
-/**
- * Wrapped Component with `React.memo`.
- * But will rerender when parent with `makeImmutable` rerender.
- */
-export function responseImmutable<T extends React.ComponentType<any>>(
-  Component: T,
-  propsAreEqual?: CompareProps<T>,
-): T {
-  const refAble = supportRef(Component);
+    const ImmutableComponent = function (props: any, ref: any) {
+      const refProps = refAble ? { ref } : {};
+      useImmutableMark();
 
-  const ImmutableComponent = function (props: any, ref: any) {
-    const refProps = refAble ? { ref } : {};
-    useImmutableMark();
+      return <Component {...props} {...refProps} />;
+    };
 
-    return <Component {...props} {...refProps} />;
-  };
+    if (process.env.NODE_ENV !== 'production') {
+      ImmutableComponent.displayName = `ImmutableResponse(${
+        Component.displayName || Component.name
+      })`;
+    }
 
-  if (process.env.NODE_ENV !== 'production') {
-    ImmutableComponent.displayName = `ImmutableResponse(${
-      Component.displayName || Component.name
-    })`;
+    return refAble
+      ? React.memo(React.forwardRef(ImmutableComponent), propsAreEqual)
+      : (React.memo(ImmutableComponent, propsAreEqual) as any);
   }
 
-  return refAble
-    ? React.memo(React.forwardRef(ImmutableComponent), propsAreEqual)
-    : (React.memo(ImmutableComponent, propsAreEqual) as any);
+  return {
+    makeImmutable,
+    responseImmutable,
+    useImmutableMark,
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,16 @@
 import type { SelectorContext } from './context';
 import { createContext, useContext } from './context';
-import { makeImmutable, responseImmutable, useImmutableMark } from './Immutable';
+import createImmutable from './Immutable';
 
-export { createContext, useContext, makeImmutable, responseImmutable, useImmutableMark };
+// For legacy usage, we export it directly
+const { makeImmutable, responseImmutable, useImmutableMark } = createImmutable();
+
+export {
+  createContext,
+  useContext,
+  createImmutable,
+  makeImmutable,
+  responseImmutable,
+  useImmutableMark,
+};
 export type { SelectorContext };


### PR DESCRIPTION
* 添加 `createImmutable` 支持，以允许不同的组件可以各自实现根据 render 更新的能力。
* `makeImmutable` 现在只会以最外面的为准。