### PR TITLE
chore: forbid rc deep imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,31 +1,9 @@
 const base = require('@umijs/fabric/dist/eslint');
 
-const restrictedPackageDirectoryImports = [
-  '@rc-component/*/es',
-  '@rc-component/*/es/**',
-  '@rc-component/*/lib',
-  '@rc-component/*/lib/**',
-  'rc-*/es',
-  'rc-*/es/**',
-  'rc-*/lib',
-  'rc-*/lib/**',
-];
-
 module.exports = {
   ...base,
   rules: {
     ...base.rules,
-    'no-restricted-imports': [
-      'error',
-      {
-        patterns: [
-          {
-            group: restrictedPackageDirectoryImports,
-            message: 'Do not import package internals from es/lib. Import from the package root.',
-          },
-        ],
-      },
-    ],
     'react/no-find-dom-node': 0,
     'jsx-a11y/label-has-associated-control': 0,
     'jsx-a11y/label-has-for': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,31 @@
 const base = require('@umijs/fabric/dist/eslint');
 
+const restrictedPackageDirectoryImports = [
+  '@rc-component/*/es',
+  '@rc-component/*/es/**',
+  '@rc-component/*/lib',
+  '@rc-component/*/lib/**',
+  'rc-*/es',
+  'rc-*/es/**',
+  'rc-*/lib',
+  'rc-*/lib/**',
+];
+
 module.exports = {
   ...base,
   rules: {
     ...base.rules,
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: restrictedPackageDirectoryImports,
+            message: 'Do not import package internals from es/lib. Import from the package root.',
+          },
+        ],
+      },
+    ],
     'react/no-find-dom-node': 0,
     'jsx-a11y/label-has-associated-control': 0,
     'jsx-a11y/label-has-for': 0,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@rc-component/util": "^1.11.0"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.4",
     "@types/jest": "^29.5.0",
     "@types/node": "^24.5.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@rc-component/util": "^1.3.0"
+    "@rc-component/util": "^1.11.0"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^2.0.2",
@@ -45,10 +45,12 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/warning": "^3.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.62.0",
+    "@typescript-eslint/parser": "^5.62.0",
     "@umijs/fabric": "^4.0.0",
     "dumi": "^2.0.15",
     "eslint": "^8.54.0",
-    "eslint-plugin-jest": "^28.2.0",
+    "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-unicorn": "^52.0.0",
     "father": "^4.0.0",
     "rc-test": "^7.0.14",
@@ -57,7 +59,7 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "react": ">=16.9.0",
-    "react-dom": ">=16.9.0"
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   }
 }

--- a/src/Immutable.tsx
+++ b/src/Immutable.tsx
@@ -1,4 +1,4 @@
-import { supportRef } from '@rc-component/util/lib/ref';
+import { supportRef } from '@rc-component/util';
 import * as React from 'react';
 
 export type CompareProps<T extends React.ComponentType<any>> = (

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,6 +1,4 @@
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import isEqual from '@rc-component/util/lib/isEqual';
+import { isEqual, useEvent, useLayoutEffect } from '@rc-component/util';
 import * as React from 'react';
 import { unstable_batchedUpdates } from 'react-dom';
 


### PR DESCRIPTION
## 背景

为避免 rc 包之间依赖其他包的 `es` / `lib` 构建产物内部路径，本次将 `@rc-component/context` 中的 rc 深路径导入统一迁移到包根入口，并补充 lint 规则阻止后续重新引入。

## 改动内容

- 新增 ESLint `no-restricted-imports` 规则，限制 `@rc-component/*` 与 `rc-*` 包的 `es` / `lib` 深路径导入。
- 将 `@rc-component/util/lib/*` 导入替换为 `@rc-component/util` 根入口导入。
- 将 `@rc-component/util` 升级到 `^1.11.0`，使用包含所需根入口导出的版本。
- 将 React peer 版本调整为 `>=18.0.0`，与当前 `@rc-component/util` 的 peer 要求保持一致。
- 固定 lint 所需的 `@typescript-eslint` v5 依赖，并将 `eslint-plugin-jest` 调整到兼容版本，避免 `@umijs/fabric` 规则加载失败。

## 验证

- `npm run lint`：通过，保留既有 2 条 `react-hooks/exhaustive-deps` warning。
- `npm run compile`：通过，保留同样 2 条 warning。
- `npm test`：通过，2 个 test suites / 10 个 tests。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 升级了核心依赖版本以提升兼容性
  * 更新了 TypeScript ESLint 工具链配置
  * 将 React 和 React DOM 最低版本要求提升至 18.0.0
  * 实现更严格的导入规则以规范模块架构
  * 优化了内部模块导入路径

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/context/pull/54)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->